### PR TITLE
Upgrade to Django 6.0 & Python 3.13

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Set up Python (3.11)
+      - name: Set up Python (3.12)
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install and run tox
         run: |
@@ -45,10 +45,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Set up Python (3.11)
+      - name: Set up Python (3.12)
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install and run tox
         run: |
@@ -60,16 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12"]
-        # build LTS version, next version, HEAD
-        django: ["32", "42", "50", "main"]
-        exclude:
-          - python: "3.10"
-            django: "main"
-          - python: "3.11"
-            django: "32"
-          - python: "3.12"
-            django: "32"
+        python: ["3.12", "3.13"]
+        django: ["52", "60", "main"]
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 node_modules
 poetry.lock
 test.db
-dist/*
+dist/
+.idea/

--- a/README
+++ b/README
@@ -2,6 +2,8 @@
 
 Simple Django model for logging HttpRequest instances.
 
+**Compatibility:** Python 3.12+ and Django 5.2-6.0
+
 ## Why?
 
 We have a number of libraries that store elements of a request (path,

--- a/demo/settings.py
+++ b/demo/settings.py
@@ -1,9 +1,4 @@
-from distutils.version import StrictVersion
 from os import path
-
-import django
-
-DJANGO_VERSION = StrictVersion(django.get_version())
 
 DEBUG = True
 TEMPLATE_DEBUG = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-request-logger-2"
-version = "0.4"
+version = "0.5.0"
 description = "Django model for storing HttpRequest information."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -13,23 +13,19 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 packages = [{ include = "request_logger" }]
 
 [tool.poetry.dependencies]
-python = "^3.10"
-django = "^3.2 || ^4.0 || ^5.0"
+python = "^3.12"
+django = ">=5.2,<7.0"
 django-rest-framework = { version = "*", optional = true }
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ django-rest-framework = { version = "*", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 black = "*"
+django-rest-framework = "*"
 coverage = "*"
 mypy = "*"
 pre-commit = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,9 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; https://docs.djangoproject.com/en/5.0/releases/
-    django32-py{310}
-    django40-py{310}
-    django41-py{310,311}
-    django42-py{310,311}
-    django50-py{310,311,312}
-    djangomain-py{311,312}
+    django52-py{312,313}
+    django60-py{312,313}
+    djangomain-py{312,313}
 
 [testenv]
 deps =
@@ -17,11 +13,8 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
-    django42: Django>=4.2,<4.3
-    django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
     ruff
 
 commands =
-    ruff request_logger
+    ruff check request_logger
 
 [testenv:mypy]
 description = Python source code type hints (mypy)


### PR DESCRIPTION
## Summary

This PR upgrades the package to support Django 6.0 and Python 3.13.

## Changes

### Added
  - ✅ Django 6.0 support
  - ✅ Python 3.12, 3.13 support

### Removed
  - ❌ Python 3.9, 3.10, 3.11 support (now requires Python 3.12+)
  - ❌ Django 4.2 and 5.0 support (now supports Django 5.2-6.0)